### PR TITLE
Added if-statement to setNodes()

### DIFF
--- a/src/com/ai/astar/AStar.java
+++ b/src/com/ai/astar/AStar.java
@@ -43,6 +43,9 @@ public class AStar {
         for (int i = 0; i < searchArea.length; i++) {
             for (int j = 0; j < searchArea[0].length; j++) {
                 Node node = new Node(i, j);
+                if(searchArea[i][j].isBlock()) { 
+                    node.setBlock(true); //In case a node was set to block outside of the setBlocks context
+                }
                 node.calculateHeuristic(getFinalNode());
                 this.searchArea[i][j] = node;
             }


### PR DESCRIPTION
Added the ability to set nodes as block through setNodes(), in case of nodes being instantiated as nodes outside of the AStar instance context. Used this modification in a university project, where the nodes (tiles in a game), where marked as blocks before being added through setSearchArea 😄 